### PR TITLE
Remove deprecation warning for Rails 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 1.9.3
 
 gemfile:
+  - gemfiles/Gemfile.activerecord-4.1.0.beta1
   - gemfiles/Gemfile.activerecord-4.0
   - gemfiles/Gemfile.activerecord-3.2.x
 

--- a/gemfiles/Gemfile.activerecord-4.1.0.beta1
+++ b/gemfiles/Gemfile.activerecord-4.1.0.beta1
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 4.1.0.beta1'

--- a/lib/active_record/json_validator/validator.rb
+++ b/lib/active_record/json_validator/validator.rb
@@ -6,12 +6,18 @@ class JsonValidator < ActiveModel::EachValidator
 
     super
 
-    inject_setter_method(options[:class], @attributes) if options[:class]
-  end
+    # Rails 4.1 and above expose a `class` option
+    if options[:class]
+      inject_setter_method(options[:class], @attributes)
 
-  # Only respond to `#setup` if we’re in Rails 4.0 or less
-  def setup(model)
-    inject_setter_method(model, @attributes)
+    # Rails 4.0 and below calls a `#setup` method
+    elsif !respond_to?(:setup)
+      class_eval do
+        define_method :setup do |model|
+          inject_setter_method(model, @attributes)
+        end
+      end
+    end
   end
 
   # Validate the JSON value with a JSON schema path or String


### PR DESCRIPTION
If we’re in Rails 4.1, use `options[:class]`. Else, define a `setup` method that Rails will call.
