### PR TITLE
Improve how we handle invalid JSON data

### DIFF
--- a/spec/json_validator_spec.rb
+++ b/spec/json_validator_spec.rb
@@ -25,23 +25,43 @@ describe JsonValidator do
     end
   end
 
+  let(:user) { User.create(attributes) }
+
   context 'with blank JSON value' do
     let(:attributes) { { name: 'Samuel Garneau', profile: {} } }
-    it { expect(User.create(attributes)).to_not be_valid }
+    it { expect(user).to_not be_valid }
   end
 
   context 'with invalid JSON value' do
-    let(:attributes) { { name: 'Samuel Garneau', profile: { city: 'Quebec City' } } }
-    it { expect(User.create(attributes)).to_not be_valid }
+    context 'as Ruby Hash' do
+      let(:attributes) { { name: 'Samuel Garneau', profile: { city: 'Quebec City' } } }
+      it { expect(user).to_not be_valid }
+    end
+
+    context 'as JSON string' do
+      let(:attributes) { { name: 'Samuel Garneau', profile: '{ "city": "Quebec City" }' } }
+      it { expect(user).to_not be_valid }
+    end
   end
 
   context 'with valid JSON value' do
-    let(:attributes) { { name: 'Samuel Garneau', profile: { country: 'CA' } } }
-    it { expect(User.create(attributes)).to be_valid }
+    context 'as Ruby Hash' do
+      let(:attributes) { { name: 'Samuel Garneau', profile: { country: 'CA' } } }
+      it { expect(user).to be_valid }
+    end
+
+    context 'as JSON string' do
+      let(:attributes) { { name: 'Samuel Garneau', profile: '{ "country": "CA" }' } }
+      it { expect(user).to be_valid }
+    end
   end
 
-  context 'with malformed JSON value' do
+  context 'with malformed JSON string' do
     let(:attributes) { { name: 'Samuel Garneau', profile: 'foo:}bar' } }
-    it { expect(User.create(attributes)).to_not be_valid }
+
+    specify do
+      expect(user).to_not be_valid
+      expect(user.profile_invalid_json).to eql('foo:}bar')
+    end
   end
 end


### PR DESCRIPTION
The invalid JSON data handling was not working properly (at least in Rails 4.2).

Now, instead of relying on `super(args)` to raise a `JSON::ParserError` while setting the value, we parse the data manually first and keep the invalid JSON data in an accessor (so we can still re-use it in a form field, for example).

I also added a few tests to make sure everything works the same regardless of which data type we use (`Hash` or `String`).