### PR TITLE
Prepare for 0.3 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: ruby
 
 rvm:
-  - 2.0.0
-  - 1.9.3
+  - 2.2
+  - 2.1
 
 gemfile:
+  - gemfiles/Gemfile.activerecord-4.2.x
   - gemfiles/Gemfile.activerecord-4.1.x
-  - gemfiles/Gemfile.activerecord-4.0.x
-  - gemfiles/Gemfile.activerecord-3.2.x
+
+sudo: false
 
 env:
   - DB_ADAPTER=mysql2

--- a/activerecord_json_validator.gemspec
+++ b/activerecord_json_validator.gemspec
@@ -20,12 +20,12 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '~> 2.14'
+  spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'pg'
   spec.add_development_dependency 'mysql2'
-  spec.add_development_dependency 'activesupport', '>= 3.0.0'
+  spec.add_development_dependency 'activesupport', '>= 4.1.0', '< 5'
 
-  spec.add_dependency 'json-schema', '~> 2.1'
-  spec.add_dependency 'activerecord', '>= 3.0.0'
+  spec.add_dependency 'json-schema', '~> 2.5'
+  spec.add_dependency 'activerecord', '>= 4.1.0', '< 5'
   spec.add_dependency 'multi_json', '~> 1.8.2'
 end

--- a/gemfiles/Gemfile.activerecord-4.0.x
+++ b/gemfiles/Gemfile.activerecord-4.0.x
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'activerecord', '~> 4.0'

--- a/gemfiles/Gemfile.activerecord-4.2.x
+++ b/gemfiles/Gemfile.activerecord-4.2.x
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'activerecord', '~> 3.2'
+gem 'activerecord', '~> 4.2'


### PR DESCRIPTION
For the 0.3 version, we’re going to drop support for older rubies and older Rails versions.

Let’s do this!