### PR TITLE
Add JSONValidator object

### DIFF
--- a/lib/active_record/json_validator/validator.rb
+++ b/lib/active_record/json_validator/validator.rb
@@ -69,3 +69,5 @@ protected
     record.instance_exec(&schema)
   end
 end
+
+JSONValidator = JsonValidator

--- a/spec/json_validator_spec.rb
+++ b/spec/json_validator_spec.rb
@@ -93,4 +93,8 @@ describe JsonValidator do
       it { expect(user).not_to be_valid }
     end
   end
+
+  context 'with JSON inflection' do
+    it { expect(JSONValidator).to equal(JsonValidator) }
+  end
 end


### PR DESCRIPTION
This pull request fix a bug occurring when inflection rules include `JSON` like this:

```
ActiveSupport::Inflector.inflections(:en) do |inflect|
  inflect.acronym 'JSON'
end
```

With these inflection rules, using JSON validator will create an argument error `Unknown validator: 'JSONValidator'`