### PR TITLE
Add ability to specify custom options for Json Validator

### DIFF
--- a/lib/active_record/json_validator/validator.rb
+++ b/lib/active_record/json_validator/validator.rb
@@ -2,6 +2,7 @@ class JsonValidator < ActiveModel::EachValidator
   def initialize(options)
     options.reverse_merge!(message: :invalid_json)
     options.reverse_merge!(schema: nil)
+    options.reverse_merge!(options: {})
     @attributes = options[:attributes]
 
     super
@@ -30,7 +31,7 @@ class JsonValidator < ActiveModel::EachValidator
 
     # Validate value with JSON::Validator
     schema = fetch_schema_for_record(record)
-    errors = ::JSON::Validator.fully_validate(schema, json_value)
+    errors = ::JSON::Validator.fully_validate(schema, json_value, options.fetch(:options))
 
     # Everything is good if we don’t have any errors and we got valid JSON value
     return true if errors.empty? && record.send(:"#{attribute}_invalid_json").blank?

--- a/spec/json_validator_spec.rb
+++ b/spec/json_validator_spec.rb
@@ -10,10 +10,11 @@ describe JsonValidator do
     end
 
     json_schema = schema
+    json_strict = strict
     spawn_model :User do
       serialize :profile, JSON
       validates :name, presence: true
-      validates :profile, presence: true, json: { schema: json_schema }
+      validates :profile, presence: true, json: { schema: json_schema, options: { strict: json_strict } }
 
       def dynamic_json_schema
         {
@@ -39,6 +40,7 @@ describe JsonValidator do
       }
     }
   end
+  let(:strict) { false }
 
   context 'with blank JSON value' do
     let(:attributes) { { name: 'Samuel Garneau', profile: {} } }
@@ -96,5 +98,11 @@ describe JsonValidator do
 
   context 'with JSON inflection' do
     it { expect(JSONValidator).to equal(JsonValidator) }
+  end
+
+  context 'with strict option' do
+    let(:strict) { true }
+    let(:attributes) { { name: 'Samuel Garneau', profile: '{ "country": "CA", "foo": "bar" }' } }
+    it { expect(user).not_to be_valid }
   end
 end


### PR DESCRIPTION
Json Validator can take additional options (like [`strict`](https://github.com/ruby-json-schema/json-schema#strictly-validate-an-objects-properties)).

This PR add the ability to specify additional options to the Json Validator.