### PR TITLE
Rewrite the whole test suite and refactor validator methods

### DIFF
--- a/activerecord_json_validator.gemspec
+++ b/activerecord_json_validator.gemspec
@@ -29,5 +29,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'json-schema', '~> 2.5'
   spec.add_dependency 'activerecord', '>= 4.1.0', '< 5'
-  spec.add_dependency 'multi_json', '~> 1.10'
 end

--- a/lib/activerecord_json_validator.rb
+++ b/lib/activerecord_json_validator.rb
@@ -1,6 +1,5 @@
 require 'active_record'
 require 'json-schema'
-require 'multi_json'
 
 require 'active_record/json_validator/version'
 require 'active_record/json_validator/validator'


### PR DESCRIPTION
The [previous test file](https://github.com/mirego/activerecord_json_validator/blob/205ddd96e3f92add3164be724ca079c6fe87d342/spec/json_validator_spec.rb) was not really testing the behavior of the validator — it was mostly just testing the external `JSON::Validator.fully_validate` method.

Now we only test *our* code and assume the `activerecord` and `json-schema` gems will do their job :smile: 

I also refactored a few methods to make them more test-friendly and embraced `ActiveSupport::JSON` to get rid of the `multi_json` dependency.