### PR TITLE
Add recursivity and Symbol support to “schema” method

### DIFF
--- a/lib/active_record/json_validator/validator.rb
+++ b/lib/active_record/json_validator/validator.rb
@@ -56,11 +56,16 @@ protected
     end
   end
 
-  def schema(record)
-    schema = options.fetch(:schema)
-    return schema unless schema.is_a?(Proc)
+  # Return a valid schema for JSON::Validator.fully_validate, recursively calling
+  # itself until it gets a non-Proc/non-Symbol value.
+  def schema(record, schema = nil)
+    schema ||= options.fetch(:schema)
 
-    record.instance_exec(&schema)
+    case schema
+      when Proc then schema(record, record.instance_exec(&schema))
+      when Symbol then schema(record, record.send(schema))
+      else schema
+    end
   end
 
   def validatable_value(value)

--- a/spec/json_validator_spec.rb
+++ b/spec/json_validator_spec.rb
@@ -93,25 +93,47 @@ describe JsonValidator do
     let(:options) { { attributes: [:foo], schema: schema_option } }
     let(:schema) { validator.send(:schema, record) }
 
-    context 'with non-Proc schema' do
+    context 'with String schema' do
       let(:schema_option) { double(:schema) }
       let(:record) { double(:record) }
 
       it { expect(schema).to eql(schema_option) }
     end
 
-    context 'with Proc schema' do
+    context 'with Proc schema returning a Proc returning a Proc' do
       let(:schema_option) { -> { dynamic_schema } }
       let(:record) { record_class.new }
       let(:record_class) do
         Class.new do
           def dynamic_schema
-            :yay
+            -> { another_dynamic_schema }
+          end
+
+          def another_dynamic_schema
+            -> { what_another_dynamic_schema }
+          end
+
+          def what_another_dynamic_schema
+            'yay'
           end
         end
       end
 
-      it { expect(schema).to eql(:yay) }
+      it { expect(schema).to eql('yay') }
+    end
+
+    context 'with Symbol schema' do
+      let(:schema_option) { :dynamic_schema }
+      let(:record) { record_class.new }
+      let(:record_class) do
+        Class.new do
+          def dynamic_schema
+            'foo'
+          end
+        end
+      end
+
+      it { expect(schema).to eql('foo') }
     end
   end
 


### PR DESCRIPTION
I started by adding support for Symbol values for the `schema` option. I ended up by adding recursion to the internal method :smile: 