### PR TITLE
Error messages by default are more descriptive, `errors_as_objects` is taken into account as an option

### DIFF
--- a/lib/active_record/json_validator/validator.rb
+++ b/lib/active_record/json_validator/validator.rb
@@ -2,7 +2,7 @@ class JsonValidator < ActiveModel::EachValidator
   def initialize(options)
     options.reverse_merge!(message: :invalid_json)
     options.reverse_merge!(schema: nil)
-    options.reverse_merge!(options: {})
+    options.reverse_merge!(options: { errors_as_objects: true })
     @attributes = options[:attributes]
 
     super
@@ -30,7 +30,14 @@ class JsonValidator < ActiveModel::EachValidator
     return if errors.empty? && record.send(:"#{attribute}_invalid_json").blank?
 
     # Add error message to the attribute
-    record.errors.add(attribute, options.fetch(:message), value: value)
+    message = options.fetch(:message)
+    errors.each do |error|
+      if message == :invalid_json && error.is_a?(String) # default
+        record.errors.add(attribute, message, value: value)
+      else
+        record.errors.add(attribute, error.is_a?(String) ? error : error.fetch(:message))
+      end
+    end
   end
 
 protected


### PR DESCRIPTION
Default options passed to the json validator now try to get errors as objects and return them describing what's wrong.
Thanks to that, `errors_as_objects` option is actually working. Previously the structure of the errors array was not taken into account.

I've wasted over 30 minutes trying to know what's wrong with my json because the error was very generic "invalid_json" and when I tried to use option to return them as errors it has changed nothing.

Now by default it will look something like this:
```ruby
[1] pry(main)> t = Trigger.first; t.update({result: { email: 1 }, condition: { directory_file: 'a'} })
  Trigger Load (8.4ms)  SELECT  "triggers".* FROM "triggers"  ORDER BY "triggers"."id" ASC LIMIT 1
   (0.9ms)  BEGIN
  Repo Load (1.5ms)  SELECT  "repos".* FROM "repos" WHERE "repos"."id" = $1 LIMIT 1  [["id", "04bf4615-ecdc-4e7a-9b2c-e13efcb35861"]]
   (0.6ms)  ROLLBACK
=> false
[2] pry(main)> t.errors
=> #<ActiveModel::Errors:0x007fc12763d9c8
 @base=
  #<Trigger:0x007fc127605c08
   id: 2,
   repo_id: "04bf4615-ecdc-4e7a-9b2c-e13efcb35861",
   active: true,
   condition_type: "PULL_REQUEST_DIRECTORY_CHANGE",
   result_type: "EMAIL",
   condition: {"directory_file"=>"a"},
   result: {"email"=>1},
   created_at: Tue, 10 Feb 2015 20:13:00 UTC +00:00,
   updated_at: Thu, 12 Feb 2015 20:24:25 UTC +00:00>,
 @messages=
  {:condition=>["translation missing: en.activerecord.errors.models.trigger.attributes.condition.invalid_json"],
   :result=>["The property '#/email' of type Fixnum did not match the following type: string in schema 2d44293f-cd9d-5dca-8a6a-fb9db1de722b#"]}>
```
for following validations:
```ruby
  validates :condition, json: { schema: lambda { dynamic_condition_schema }, options: { errors_as_objects: false }}, allow_nil: true
  validates :result, json: { schema: lambda { dynamic_result_schema } }, allow_nil: true
```

and following schemas:
```ruby

  SCHEMA_DEFAULTS = {
    type:      'object',
    :'$schema' => 'http://json-schema.org/draft-04/schema',
  }

  def condition_pull_request_directory_change_schema
    SCHEMA_DEFAULTS.deep_merge(
      {
        properties: {
          directory_path: { type: 'string' },
        },
        required:   ['directory_path']
      })
  end

  def result_email_schema
    SCHEMA_DEFAULTS.deep_merge(
      {
        properties: {
          email: { type: 'string' },
        },
        required:   ['email']
      })
  end
```

I'm not sure if there needs to be a README update? 