### PR TITLE
Add support for “callable” message option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,31 @@ user.profile_invalid_json # => '{invalid JSON":}'
 | Option     | Description
 |------------|-----------------------------------------------------
 | `:schema`  | The JSON schema to validate the data against (see **JSON schema option** section)
-| `:message` | The ActiveRecord message added to the record errors (default: `:invalid_json`)
+| `:message` | The ActiveRecord message added to the record errors (see **Message option**)
+
+##### Message option
+
+Like any other ActiveModel validation, you can specify either a `Symbol` or
+`String` value for the `:message` option. The default value is `:invalid_json`.
+
+However, you can also specify a `Proc` that returns an array of errors. The
+`Proc` will be called with a single argument — an array of errors returned by
+the JSON schema validator. So, if you’d like to add each of these errors as
+a first-level error for the record, you can do this:
+
+```ruby
+class User < ActiveRecord::Base
+  # Validations
+  validates :profile, presence: true, json: { message: ->(errors) { errors }, schema: 'foo.json_schema' }
+end
+
+user = User.new.tap(&:valid?)
+user.errors.full_messages
+# => [
+#      'The property '#/email' of type Fixnum did not match the following type: string in schema 2d44293f-cd9d-5dca-8a6a-fb9db1de722b#',
+#      'The property '#/full_name' of type Fixnum did not match the following type: string in schema 2d44293f-cd9d-5dca-8a6a-fb9db1de722b#',
+#    ]
+```
 
 ##### JSON schema option
 

--- a/lib/active_record/json_validator/validator.rb
+++ b/lib/active_record/json_validator/validator.rb
@@ -30,7 +30,9 @@ class JsonValidator < ActiveModel::EachValidator
     return if errors.empty? && record.send(:"#{attribute}_invalid_json").blank?
 
     # Add error message to the attribute
-    record.errors.add(attribute, options.fetch(:message), value: value)
+    message(errors).each do |error|
+      record.errors.add(attribute, error, value: value)
+    end
   end
 
 protected
@@ -71,5 +73,14 @@ protected
   def validatable_value(value)
     return value if value.is_a?(String)
     ::ActiveSupport::JSON.encode(value)
+  end
+
+  def message(errors)
+    message = options.fetch(:message)
+
+    case message
+      when Proc then [message.call(errors)].flatten if message.is_a?(Proc)
+      else [message]
+    end
   end
 end


### PR DESCRIPTION
Inspired by #16, I decided we could add support for a *callable* `:message` option. This feature is defined in `README.md`.