### PR TITLE
Bump json-schema to 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ IfUnlessModifier:
   Enabled: false
 
 CaseIndentation:
-  IndentWhenRelativeTo: case
+  EnforcedStyle: case
   IndentOneStep: true
 
 MethodLength:

--- a/activerecord_json_validator.gemspec
+++ b/activerecord_json_validator.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'phare'
   spec.add_development_dependency 'rubocop', '~> 0.28'
 
-  spec.add_dependency 'json-schema', '~> 2.7'
+  spec.add_dependency 'json-schema', '~> 2.8'
   spec.add_dependency 'activerecord', '>= 4.2.0', '< 6'
 end

--- a/activerecord_json_validator.gemspec
+++ b/activerecord_json_validator.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'phare'
   spec.add_development_dependency 'rubocop', '~> 0.28'
 
-  spec.add_dependency 'json-schema', '~> 2.6'
+  spec.add_dependency 'json-schema', '~> 2.7'
   spec.add_dependency 'activerecord', '>= 4.2.0', '< 6'
 end


### PR DESCRIPTION
[json-schema](https://github.com/ruby-json-schema/json-schema/releases) is now on 2.7. This will remove the Fixnum deprecation warnings