### PR TITLE
Makes it work on virtual attributes. Adds SQLITE support for tests.

### DIFF
--- a/activerecord_json_validator.gemspec
+++ b/activerecord_json_validator.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.5'
   spec.add_development_dependency 'pg'
   spec.add_development_dependency 'mysql2'
+  spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'activesupport', '>= 4.2.0', '< 6'
   spec.add_development_dependency 'phare'
   spec.add_development_dependency 'rubocop', '~> 0.28'

--- a/lib/active_record/json_validator/validator.rb
+++ b/lib/active_record/json_validator/validator.rb
@@ -28,32 +28,54 @@ protected
 
   # Redefine the setter method for the attributes, since we want to
   # catch JSON parsing errors.
+  # Things are handled differently between virtual attributes and
+  # database columns.
   def inject_setter_method(klass, attributes)
+    inject_base_string_setter(klass)
+
     attributes.each do |attribute|
-      klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-        attr_reader :"#{attribute}_invalid_json"
-        
-        if use_alias = method_defined?("#{attribute}=")
-          alias_method "json_validator_old_#{attribute}=", "#{attribute}="
-        end
+      klass.class_eval "attr_reader :#{attribute}_invalid_json"
 
-        define_method "#{attribute}=" do |args|
-          json = begin
-            @#{attribute}_invalid_json = nil
-            ::ActiveSupport::JSON.decode(args) if args.is_a?(::String)
-          rescue ActiveSupport::JSON.parse_error
-            @#{attribute}_invalid_json = args
-            {}
-          end
-
-          if use_alias
-            self.json_validator_old_#{attribute} = json
-          else
-            super(json)
-          end
-        end
-      RUBY
+      if klass.class_eval { method_defined?("#{attribute}=") }
+        inject_virtual_attribute_setter_method(klass, attribute)
+      else
+        inject_database_column_setter_method(klass, attribute)
+      end
     end
+  end
+
+  def inject_base_string_setter(klass)
+    klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+      define_method :json_validator_string_setter do |attr, args|
+        begin
+          args = ::ActiveSupport::JSON.decode(args) if args.is_a?(::String)
+          instance_variable_set('@'+attr.to_s+'_invalid_json', nil)
+          args
+        rescue ActiveSupport::JSON.parse_error
+          instance_variable_set('@'+attr.to_s+'_invalid_json', args)
+          {}
+        end
+      end
+    RUBY
+  end
+
+  def inject_virtual_attribute_setter_method(klass, attribute)
+    klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+      alias_method "json_validator_old_#{attribute}=", "#{attribute}="
+
+      define_method "#{attribute}=" do |args|
+        self.json_validator_old_#{attribute} =
+          json_validator_string_setter(:#{attribute}, args)
+      end
+    RUBY
+  end
+
+  def inject_database_column_setter_method(klass, attribute)
+    klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+      define_method "#{attribute}=" do |args|
+        super(json_validator_string_setter(:#{attribute}, args))
+      end
+    RUBY
   end
 
   # Return a valid schema for JSON::Validator.fully_validate, recursively calling

--- a/lib/active_record/json_validator/validator.rb
+++ b/lib/active_record/json_validator/validator.rb
@@ -43,6 +43,7 @@ protected
             ::ActiveSupport::JSON.decode(args) if args.is_a?(::String)
           rescue ActiveSupport::JSON.parse_error
             @#{attribute}_invalid_json = args
+            {}
           end
 
           if use_alias

--- a/lib/active_record/json_validator/version.rb
+++ b/lib/active_record/json_validator/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module JSONValidator
-    VERSION = '1.2.0'.freeze
+    VERSION = '1.2.1'.freeze
   end
 end

--- a/spec/json_validator_spec.rb
+++ b/spec/json_validator_spec.rb
@@ -196,8 +196,7 @@ describe JsonValidator do
 
       spawn_model 'User' do
         attr_accessor :data
-        serialize :data, JSON
-        validates :data, json: true
+        validates :data, json: { schema: '{}' }
       end
 
       record.data = data
@@ -213,6 +212,11 @@ describe JsonValidator do
     context 'with invalid JSON data' do
       let(:data) { { foo: 'bar' } }
       it { expect(record.data_invalid_json).to be_nil }
+      it do
+        record.save
+        record.reload
+        expect(record.data).to eql(data)
+      end
     end
   end
 end

--- a/spec/json_validator_spec.rb
+++ b/spec/json_validator_spec.rb
@@ -185,5 +185,35 @@ describe JsonValidator do
       it { expect(message).to eql(%i(first_error second_error)) }
     end
   end
+
+  describe :works_on_virtual_attributes do
+    before do
+      run_migration do
+        create_table(:users, force: true) do |t|
+          t.string :name
+        end
+      end
+
+      spawn_model 'User' do
+        attr_accessor :data
+        serialize :data, JSON
+        validates :data, json: true
+      end
+
+      record.data = data
+    end
+
+    let(:record) { User.new }
+
+    context 'with valid JSON data' do
+      let(:data) { 'What? This is not JSON at all.' }
+      it { expect(record.data_invalid_json).to eql(data) }
+    end
+
+    context 'with invalid JSON data' do
+      let(:data) { { foo: 'bar' } }
+      it { expect(record.data_invalid_json).to be_nil }
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ RSpec.configure do |config|
   config.include ModelMacros
 
   config.before :each do
-    adapter = ENV['DB_ADAPTER'] || 'postgresql'
+    adapter = ENV['DB_ADAPTER'] || 'sqlite3'
     @database_adapter = setup_database(adapter: adapter, database: 'activerecord_json_validator_test')
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'active_support/all'
 require 'rspec'
 require 'mysql2'
 require 'pg'
+require 'sqlite3'
 
 require 'activerecord_json_validator'
 
@@ -17,6 +18,10 @@ RSpec.configure do |config|
 
   config.before :each do
     adapter = ENV['DB_ADAPTER'] || 'postgresql'
-    setup_database(adapter: adapter, database: 'activerecord_json_validator_test')
+    @database_adapter = setup_database(adapter: adapter, database: 'activerecord_json_validator_test')
+  end
+
+  config.after :each do
+    @database_adapter.cleanup!
   end
 end

--- a/spec/support/macros/database/database_adapter.rb
+++ b/spec/support/macros/database/database_adapter.rb
@@ -7,9 +7,7 @@ class DatabaseAdapter
     ActiveRecord::Base.establish_connection(database_configuration)
   end
 
-  def reset_database!
-  end
+  def reset_database!; end
 
-  def cleanup!
-  end
+  def cleanup!; end
 end

--- a/spec/support/macros/database/database_adapter.rb
+++ b/spec/support/macros/database/database_adapter.rb
@@ -6,4 +6,10 @@ class DatabaseAdapter
   def establish_connection!
     ActiveRecord::Base.establish_connection(database_configuration)
   end
+
+  def reset_database!
+  end
+
+  def cleanup!
+  end
 end

--- a/spec/support/macros/database/sqlite_adapter.rb
+++ b/spec/support/macros/database/sqlite_adapter.rb
@@ -11,6 +11,6 @@ class Sqlite3Adapter < DatabaseAdapter
   end
 
   def cleanup!
-    `rm #{@database}.sqlite` if File.exists?("#{@database}.sqlite")
+    `rm #{@database}.sqlite` if File.exist?("#{@database}.sqlite")
   end
 end

--- a/spec/support/macros/database/sqlite_adapter.rb
+++ b/spec/support/macros/database/sqlite_adapter.rb
@@ -1,0 +1,16 @@
+require_relative 'database_adapter'
+
+class Sqlite3Adapter < DatabaseAdapter
+  def database_configuration
+    {
+      adapter: 'sqlite3',
+      database: "#{@database}.sqlite",
+      username: 'travis',
+      encoding: 'utf8'
+    }
+  end
+
+  def cleanup!
+    `rm #{@database}.sqlite` if File.exists?("#{@database}.sqlite")
+  end
+end

--- a/spec/support/macros/database_macros.rb
+++ b/spec/support/macros/database_macros.rb
@@ -18,5 +18,7 @@ module DatabaseMacros
 
     # Silence everything
     ActiveRecord::Base.logger = ActiveRecord::Migration.verbose = false
+
+    adapter
   end
 end


### PR DESCRIPTION
The gem overrides the attribute setter to catch parse errors. The the new setter does its thing, then calls super, which is OK for active record.

Virtual attributes are defined as just a setter and a getter, there is no super to call, setting the value always fails.

This fix will alias any existing setters to a new method, then makes the new setter call the old setter instead of 'super'.

I've also added sqlite3 support as I don't have postgres installed. I made sqlite the default as a suggestion to keep it that way, to help others contribute.

cheers!