### PR TITLE
Use json schemer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,31 @@ gem 'activerecord_json_validator'
 ## Usage
 
 ### JSON Schema
+Schemas must use be a JSON string or use string keys.
 
 ```json
-{
+'{
   "type": "object",
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "city": { "type": "string" },
     "country": { "type": "string" }
   },
   "required": ["country"]
+}'
+```
+
+or
+
+```ruby
+{
+  "type" => "object",
+  "$schema" => "http://json-schema.org/draft-04/schema#",
+  "properties" => {
+    "city" => { "type" => "string" },
+    "country" => { "type" => "string" }
+  },
+  "required" => ["country"]
 }
 ```
 
@@ -69,13 +84,12 @@ user.profile_invalid_json # => '{invalid JSON":}'
 |------------|-----------------------------------------------------
 | `:schema`  | The JSON schema to validate the data against (see **Schema** section)
 | `:message` | The ActiveRecord message added to the record errors (see **Message** section)
-| `:options` | A `Hash` of [`json-schema`](https://github.com/ruby-json-schema/json-schema)-supported options to pass to the validator
+| `:options` | A `Hash` of [`json_schemer`](https://github.com/davishmcclurg/json_schemer#options)-supported options to pass to the validator
 
 ##### Schema
 
-`ActiveRecord::JSONValidator` uses the `json-schema` gem to validate the JSON
-data against a JSON schema. You can use [any value](https://github.com/ruby-json-schema/json-schema/tree/master#usage) that
-`JSON::Validator.validate` would take as the `schema` argument.
+`ActiveRecord::JSONValidator` uses the [json_schemer](https://github.com/davishmcclurg/json_schemer) gem to validate the JSON
+data against a JSON schema. 
 
 Additionally, you can use a `Symbol` or a `Proc`. Both will be executed in the
 context of the validated record (`Symbol` will be sent as a method and the

--- a/activerecord_json_validator.gemspec
+++ b/activerecord_json_validator.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'phare'
   spec.add_development_dependency 'rubocop', '~> 0.28'
 
-  spec.add_dependency 'json-schema', '~> 2.8'
+  spec.add_dependency 'json_schemer', '~> 0.2.18'
   spec.add_dependency 'activerecord', '>= 4.2.0', '< 7'
 end

--- a/lib/active_record/json_validator/validator.rb
+++ b/lib/active_record/json_validator/validator.rb
@@ -14,8 +14,8 @@ class JsonValidator < ActiveModel::EachValidator
 
   # Validate the JSON value with a JSON schema path or String
   def validate_each(record, attribute, value)
-    # Validate value with JSON::Validator
-    errors = ::JSON::Validator.fully_validate(schema(record), validatable_value(value), options.fetch(:options))
+    # Validate value with JSON Schemer
+    errors = JSONSchemer.schema(schema(record), options.fetch(:options)).validate(value).to_a
 
     # Everything is good if we don’t have any errors and we got valid JSON value
     return if errors.empty? && record.send(:"#{attribute}_invalid_json").blank?
@@ -49,7 +49,7 @@ protected
     end
   end
 
-  # Return a valid schema for JSON::Validator.fully_validate, recursively calling
+  # Return a valid schema, recursively calling
   # itself until it gets a non-Proc/non-Symbol value.
   def schema(record, schema = nil)
     schema ||= options.fetch(:schema)
@@ -59,12 +59,6 @@ protected
       when Symbol then schema(record, record.send(schema))
       else schema
     end
-  end
-
-  def validatable_value(value)
-    return value if value.is_a?(String)
-
-    ::ActiveSupport::JSON.encode(value)
   end
 
   def message(errors)

--- a/lib/active_record/json_validator/version.rb
+++ b/lib/active_record/json_validator/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module JSONValidator
-    VERSION = '1.3.0'
+    VERSION = '2.0.0'
   end
 end

--- a/lib/activerecord_json_validator.rb
+++ b/lib/activerecord_json_validator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_record'
-require 'json-schema'
+require 'json_schemer'
 
 require 'active_record/json_validator/version'
 require 'active_record/json_validator/validator'


### PR DESCRIPTION
### Summary
Replace json-schema gem with json_schemer. json-schema is no longer maintained (ruby-json-schema/json-schema/issues/423) and only supports up to draft 4. Replace with [json_schemer](https://github.com/davishmcclurg/json_schemer) which supports draft 4, 6 and 7.

Major version bump because this change fully drops support of drafts 1, 2 and 3. 

Closes issue #45 .

### Caveats
- Schema URL is more strict. Updated readme.
- Schema must be string json or ruby keys must be strings. Updated readme.
- Values must be ruby objects or string key objects. They can no longer be json strings. Removed the validatable_value method accordingly. Values passed in will have to adhere to this.
- Options available with the json-schemer gem are different than the json-schema gems and no attempts were made to support those.
- Finally, there may be things about what this gem needs to do for different use cases that I missed testing/updating. 

### Testing
- [X] rspec passes. 
- [x] Used the updated gem to test validation in a rails project using json drafts 4 and 6. Previously, validation failed on the draft 6 validations with: `Schema not found: http://json-schema.org/draft-06/schema#` because json-schema didn't recognize the schema. With these changes, it's able to validate both the draft 4 schema as previous and also the draft 6.


