### PR TITLE
use the splat operator when calling JSONSchemer

### DIFF
--- a/lib/active_record/json_validator/validator.rb
+++ b/lib/active_record/json_validator/validator.rb
@@ -15,7 +15,7 @@ class JsonValidator < ActiveModel::EachValidator
   # Validate the JSON value with a JSON schema path or String
   def validate_each(record, attribute, value)
     # Validate value with JSON Schemer
-    errors = JSONSchemer.schema(schema(record), options.fetch(:options)).validate(value).to_a
+    errors = JSONSchemer.schema(schema(record), **options.fetch(:options)).validate(value).to_a
 
     # Everything is good if we don’t have any errors and we got valid JSON value
     return if errors.empty? && record.send(:"#{attribute}_invalid_json").blank?


### PR DESCRIPTION
if the splat operator is not used when running with `ruby 3.0.1` and `rails 6.1.4` the following error is raised because the splat operator is required `ArgumentError Exception: wrong number of arguments (given 2, expected 1)`

_might be required elsewhere but I only had the error raised on this line_