### PR TITLE
Fix dynamic schema README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ end
 
 class User < ActiveRecord::Base
   # Constants
-  PROFILE_JSON_SCHEMA = Pathname.new(Rails.root.join('config', 'schemas', 'profile.json'))
+  PROFILE_JSON_SCHEMA = Rails.root.join('config', 'schemas', 'profile.json')
 
   # Validations
   validates :name, presence: true
@@ -85,8 +85,8 @@ context of the validated record (`Symbol` will be sent as a method and the
 ```ruby
 class User < ActiveRecord::Base
   # Constants
-  PROFILE_REGULAR_JSON_SCHEMA = Rails.root.join('config', 'schemas', 'profile.json_schema').to_s
-  PROFILE_ADMIN_JSON_SCHEMA = Rails.root.join('config', 'schemas', 'profile_admin.json_schema').to_s
+  PROFILE_REGULAR_JSON_SCHEMA = Rails.root.join('config', 'schemas', 'profile.json_schema')
+  PROFILE_ADMIN_JSON_SCHEMA = Rails.root.join('config', 'schemas', 'profile_admin.json_schema')
 
   # Validations
   validates :profile, presence: true, json: { schema: lambda { dynamic_profile_schema } } # `schema: :dynamic_profile_schema` would also work


### PR DESCRIPTION
After migrating to json schemer in #46, passing a string path as the schema will raise JSON::ParserError. Seems a similar fix was merged in #49, but this example was missed. 

Wrapping in Pathname.new was unnecessary, as Rails.root.join returns a Pathname. I removed that to make the examples consistent. 

Thank you for maintaining this project! 