### PR TITLE
Use the actual attribute value for validation

### DIFF
--- a/lib/active_record/json_validator/validator.rb
+++ b/lib/active_record/json_validator/validator.rb
@@ -13,7 +13,10 @@ class JsonValidator < ActiveModel::EachValidator
   end
 
   # Validate the JSON value with a JSON schema path or String
-  def validate_each(record, attribute, value)
+  def validate_each(record, attribute, _value)
+    # Get the _actual_ attribute value, not the getter method value
+    value = record[attribute]
+
     # Validate value with JSON Schemer
     errors = JSONSchemer.schema(schema(record), **options.fetch(:options)).validate(value).to_a
 

--- a/spec/json_validator_spec.rb
+++ b/spec/json_validator_spec.rb
@@ -9,6 +9,7 @@ describe JsonValidator do
       run_migration do
         create_table(:users, force: true) do |t|
           t.text :data
+          t.json :smart_data
         end
       end
 
@@ -27,11 +28,16 @@ describe JsonValidator do
         serialize :other_data, JSON
         validates :data, json: { schema: schema, message: ->(errors) { errors } }
         validates :other_data, json: { schema: schema, message: ->(errors) { errors.map { |error| error['details'].to_a.flatten.join(' ') } } }
+        validates :smart_data, json: { schema: schema, message: ->(errors) { errors } }
+
+        def smart_data
+          OpenStruct.new(self[:smart_data])
+        end
       end
     end
 
     context 'with valid JSON data but schema errors' do
-      let(:user) { User.new(data: '{"city":"Quebec City"}', other_data: '{"city":"Quebec City"}') }
+      let(:user) { User.new(data: '{"city":"Quebec City"}', other_data: '{"city":"Quebec City"}', smart_data: {country: "Canada", city: "Quebec City"}) }
 
       specify do
         expect(user).not_to be_valid

--- a/spec/json_validator_spec.rb
+++ b/spec/json_validator_spec.rb
@@ -37,7 +37,13 @@ describe JsonValidator do
     end
 
     context 'with valid JSON data but schema errors' do
-      let(:user) { User.new(data: '{"city":"Quebec City"}', other_data: '{"city":"Quebec City"}', smart_data: { country: 'Canada', city: 'Quebec City' }) }
+      let(:user) do
+        User.new(
+          data: '{"city":"Quebec City"}',
+          other_data: '{"city":"Quebec City"}',
+          smart_data: { country: 'Canada', city: 'Quebec City' }
+        )
+      end
 
       specify do
         expect(user).not_to be_valid

--- a/spec/json_validator_spec.rb
+++ b/spec/json_validator_spec.rb
@@ -37,7 +37,7 @@ describe JsonValidator do
     end
 
     context 'with valid JSON data but schema errors' do
-      let(:user) { User.new(data: '{"city":"Quebec City"}', other_data: '{"city":"Quebec City"}', smart_data: {country: "Canada", city: "Quebec City"}) }
+      let(:user) { User.new(data: '{"city":"Quebec City"}', other_data: '{"city":"Quebec City"}', smart_data: { country: 'Canada', city: 'Quebec City' }) }
 
       specify do
         expect(user).not_to be_valid


### PR DESCRIPTION
`JsonValidator` was using the _value_ argument in its `validate_each` method:

```ruby
def validate_each(record, attribute, value)
  errors = JSONSchemer.schema(…).validate(value).to_a
```

But that might cause problems if a JSON column is used with a custom _getter_ method. Let’s take this very simple example:

```ruby
class SomeModel < ApplicationRecord
  validates :some_data, json: { schema: … }

  def some_data
    OpenStruct.new(self[:some_data])
  end
end
```

The above code would fail any validation because the validators receives an `OpenStruct`, not a `Hash`. So now `JsonValidator` uses the _actual attribute value_:

```ruby
def validate_each(record, attribute, value)
  errors = JSONSchemer.schema(…).validate(record[attribute]).to_a
```

This should fix #62.
