### PR TITLE
Revert default behavior for value to validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ user.profile_invalid_json # => '{invalid JSON":}'
 | Option     | Description                                                                                                                    |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `:schema`  | The JSON schema to validate the data against (see **Schema** section)                                                          |
-| `:value`   | The actual value to use when validating (see **Message** section)                                                              |
+| `:value`   | The actual value to use when validating (see **Value** section)                                                                |
 | `:message` | The ActiveRecord message added to the record errors (see **Message** section)                                                  |
 | `:options` | A `Hash` of [`json_schemer`](https://github.com/davishmcclurg/json_schemer#options)-supported options to pass to the validator |
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ user.profile_invalid_json # => '{invalid JSON":}'
 | Option     | Description                                                                                                                    |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `:schema`  | The JSON schema to validate the data against (see **Schema** section)                                                          |
+| `:value`   | The actual value to use when validating (see **Message** section)                                                              |
 | `:message` | The ActiveRecord message added to the record errors (see **Message** section)                                                  |
 | `:options` | A `Hash` of [`json_schemer`](https://github.com/davishmcclurg/json_schemer#options)-supported options to pass to the validator |
 
@@ -108,6 +109,34 @@ class User < ActiveRecord::Base
 
   # Validations
   validates :profile, presence: true, json: { schema: JSON_SCHEMA }
+end
+```
+
+##### Value
+
+By default, the validator will use the “getter” method to the fetch attribute
+value and validate the schema against it.
+
+```ruby
+# Will validate `self.foo`
+validates :foo, json: { schema: SCHEMA }
+```
+
+But you can change this behavior if the getter method doesn’t return raw JSON data (a `Hash`):
+
+```ruby
+# Will validate `self[:foo]`
+validates :foo, json: { schema: SCHEMA, value: ->(record, _, _) { record[:foo] } }
+```
+
+You could also implement a “raw getter” if you want to avoid the `value` option:
+
+```ruby
+# Will validate `self[:foo]`
+validates :raw_foo, json: { schema: SCHEMA }
+
+def raw_foo
+  self[:foo]
 end
 ```
 

--- a/lib/active_record/json_validator/validator.rb
+++ b/lib/active_record/json_validator/validator.rb
@@ -5,6 +5,7 @@ class JsonValidator < ActiveModel::EachValidator
     options.reverse_merge!(message: :invalid_json)
     options.reverse_merge!(schema: nil)
     options.reverse_merge!(options: {})
+    options.reverse_merge!(value: ->(record, attribute, value) { value })
     @attributes = options[:attributes]
 
     super
@@ -13,9 +14,9 @@ class JsonValidator < ActiveModel::EachValidator
   end
 
   # Validate the JSON value with a JSON schema path or String
-  def validate_each(record, attribute, _value)
+  def validate_each(record, attribute, value)
     # Get the _actual_ attribute value, not the getter method value
-    value = record[attribute]
+    value = options.fetch(:value).(record, attribute, value)
 
     # Validate value with JSON Schemer
     errors = JSONSchemer.schema(schema(record), **options.fetch(:options)).validate(value).to_a

--- a/lib/active_record/json_validator/validator.rb
+++ b/lib/active_record/json_validator/validator.rb
@@ -5,7 +5,7 @@ class JsonValidator < ActiveModel::EachValidator
     options.reverse_merge!(message: :invalid_json)
     options.reverse_merge!(schema: nil)
     options.reverse_merge!(options: {})
-    options.reverse_merge!(value: ->(record, attribute, value) { value })
+    options.reverse_merge!(value: ->(_record, _attribute, value) { value })
     @attributes = options[:attributes]
 
     super
@@ -16,7 +16,7 @@ class JsonValidator < ActiveModel::EachValidator
   # Validate the JSON value with a JSON schema path or String
   def validate_each(record, attribute, value)
     # Get the _actual_ attribute value, not the getter method value
-    value = options.fetch(:value).(record, attribute, value)
+    value = options.fetch(:value).call(record, attribute, value)
 
     # Validate value with JSON Schemer
     errors = JSONSchemer.schema(schema(record), **options.fetch(:options)).validate(value).to_a

--- a/spec/json_validator_spec.rb
+++ b/spec/json_validator_spec.rb
@@ -28,7 +28,7 @@ describe JsonValidator do
         serialize :other_data, JSON
         validates :data, json: { schema: schema, message: ->(errors) { errors } }
         validates :other_data, json: { schema: schema, message: ->(errors) { errors.map { |error| error['details'].to_a.flatten.join(' ') } } }
-        validates :smart_data, json: { schema: schema, message: ->(errors) { errors } }
+        validates :smart_data, json: { value: ->(record, _, _) { record[:smart_data] }, schema: schema, message: ->(errors) { errors } }
 
         def smart_data
           OpenStruct.new(self[:smart_data])


### PR DESCRIPTION
As @Icmen mentionned in #63, changing the behavior to fetch the value to validate has a negative effect in other cases.

So let’s revert back to the previous behavior but add a `value` option to override which value to use.

/cc @kyrofa @Icmen