### PR TITLE
Update default version to 2.1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'activerecord_json_validator', '~> 2.0.0'
+gem 'activerecord_json_validator', '~> 2.1.0'
 ```
 
 ## Usage


### PR DESCRIPTION
Using `~> 2.0.0` resolved to `2.0.1` by default for me, and that version isn't compatible with Rails 7: 

<img width="759" alt="Screenshot 2023-03-30 at 23 12 13" src="https://user-images.githubusercontent.com/3893573/228975363-77ce6801-c0eb-4083-b091-a432830a454e.png">
