### PR TITLE
Add support for error details when adding attribute error

### DIFF
--- a/lib/active_record/json_validator/validator.rb
+++ b/lib/active_record/json_validator/validator.rb
@@ -25,9 +25,10 @@ class JsonValidator < ActiveModel::EachValidator
     return if errors.empty? && record.send(:"#{attribute}_invalid_json").blank?
 
     # Add error message to the attribute
+    details = errors.map { |e| JSONSchemer::Errors.pretty(e) }
     message(errors).each do |error|
-      error = error.is_a?(Hash) ? JSONSchemer::Errors.pretty(error) : error
-      record.errors.add(attribute, error, value: value)
+      error = JSONSchemer::Errors.pretty(error) if error.is_a?(Hash)
+      record.errors.add(attribute, error, errors: details, value: value)
     end
   end
 
@@ -68,10 +69,7 @@ protected
 
   def message(errors)
     message = options.fetch(:message)
-
-    case message
-      when Proc then [message.call(errors)].flatten if message.is_a?(Proc)
-      else [message]
-    end
+    message = message.call(errors) if message.is_a?(Proc)
+    [message].flatten
   end
 end

--- a/spec/json_validator_spec.rb
+++ b/spec/json_validator_spec.rb
@@ -48,6 +48,12 @@ describe JsonValidator do
       specify do
         expect(user).not_to be_valid
         expect(user.errors.full_messages).to eql(['Data root is missing required keys: country', 'Other data missing_keys country'])
+        expect(user.errors.group_by_attribute[:data].first).to have_attributes(
+          options: include(errors: ['root is missing required keys: country'])
+        )
+        expect(user.errors.group_by_attribute[:other_data].first).to have_attributes(
+          options: include(errors: ['root is missing required keys: country'])
+        )
         expect(user.data).to eql({ 'city' => 'Quebec City' })
         expect(user.data_invalid_json).to be_nil
       end


### PR DESCRIPTION
As mention in #68, this PR adds support for including error details from `JSONSchemer` to `ActiveModel::Error`'s option so they can be used in i.e. translated error messages.

Please let me know what you think.