### PR TITLE
Add docker-compose.yml for easy testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,15 @@ user.errors.full_messages
 #    ]
 ```
 
+## Development
+
+The tests require a database. We've provided a simple `docker-compose.yml` that will make
+it trivial to run the tests against PostgreSQL. Simply run `docker compose up -d`
+followed by `rake spec`. When you're done, run `docker compose down` to stop the database.
+
+In order to use another database, simply define the `DATABASE_URL` environment variable
+appropriately.
+
 ## License
 
 `ActiveRecord::JSONValidator` is © 2013-2022 [Mirego](https://www.mirego.com) and may be freely distributed under the [New BSD license](https://opensource.org/licenses/BSD-3-Clause). See the [`LICENSE.md`](https://github.com/mirego/activerecord_json_validator/blob/master/LICENSE.md) file.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.2'
+
+services:
+  postgres:
+    image: postgres:10
+    ports:
+      - 5432:5432
+    restart: on-failure
+    environment:
+      POSTGRES_DB: activerecord_json_validator_test
+      POSTGRES_HOST_AUTH_METHOD: trust # don't require password

--- a/spec/support/macros/database/database_adapter.rb
+++ b/spec/support/macros/database/database_adapter.rb
@@ -6,6 +6,6 @@ class DatabaseAdapter
   end
 
   def establish_connection!
-    ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
+    ActiveRecord::Base.establish_connection(ENV.fetch('DATABASE_URL', 'postgres://postgres@localhost/activerecord_json_validator_test'))
   end
 end


### PR DESCRIPTION
Requiring the developer to have a database in order to run tests raises a barrier to entry in contributing to this repository. We can simplify it by adding a `docker-compose.yml` file to fire up a properly-configured PostgreSQL database that is used by default. Also add a quick blurb about how to use it and run tests in the README.