### PR TITLE
spec: set logger to `nil` rather than `false`

### DIFF
--- a/spec/support/macros/database_macros.rb
+++ b/spec/support/macros/database_macros.rb
@@ -25,6 +25,7 @@ module DatabaseMacros
     adapter.reset_database!
 
     # Silence everything
-    ActiveRecord::Base.logger = ActiveRecord::Migration.verbose = false
+    ActiveRecord::Base.logger = nil
+    ActiveRecord::Migration.verbose = false
   end
 end


### PR DESCRIPTION
Beginning in ActiveSupport 7.1, the check for whether a logger is silenced sends `nil?`, so things break if we set the logger to `false`.

Fortunately, using `nil` also works in older versions of ActiveSupport.