### PR TITLE
gemspec: require activerecord >= 6.1.0

### DIFF
--- a/activerecord_json_validator.gemspec
+++ b/activerecord_json_validator.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.5'
   spec.add_development_dependency 'pg'
-  spec.add_development_dependency 'activesupport', '>= 4.2.0', '< 8'
+  spec.add_development_dependency 'activesupport', '>= 6.1.0', '< 8'
   spec.add_development_dependency 'rubocop', '~> 0.28'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.44'
   spec.add_development_dependency 'rubocop-standard', '~> 6.0'
 
   spec.add_dependency 'json_schemer', '~> 0.2.18'
-  spec.add_dependency 'activerecord', '>= 4.2.0', '< 8'
+  spec.add_dependency 'activerecord', '>= 6.1.0', '< 8'
 end


### PR DESCRIPTION
The setter method that JsonValidator injects into the model invokes `super`, but the superclass setter doesn't appear to exist in activesupport versions prior to 6.1.