### PR TITLE
Update to JSON Schemer v2.1

### DIFF
--- a/activerecord_json_validator.gemspec
+++ b/activerecord_json_validator.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec', '~> 1.44'
   spec.add_development_dependency 'rubocop-standard', '~> 6.0'
 
-  spec.add_dependency 'json_schemer', '~> 0.2.18'
+  spec.add_dependency 'json_schemer', '~> 2.1.1'
   spec.add_dependency 'activerecord', '>= 4.2.0', '< 8'
 end


### PR DESCRIPTION
This allows use of newer dialects of JSON Schema.

All specs pass in Ruby 2.7 - Ruby 3.2 and ActiveRecord 6.1 - 7.1.

Since this gem allows `json_schemer` options to be specified and passed through, and JSON Schemer options changed in some breaking ways since version 0.2, a major version bump here in this gem would probably make sense.
