### PR TITLE
Use json_schemer 2.0

### DIFF
--- a/activerecord_json_validator.gemspec
+++ b/activerecord_json_validator.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec', '~> 1.44'
   spec.add_development_dependency 'rubocop-standard', '~> 6.0'
 
-  spec.add_dependency 'json_schemer', '~> 0.2.18'
+  spec.add_dependency 'json_schemer', '~> 2.0'
   spec.add_dependency 'activerecord', '>= 4.2.0', '< 8'
 end

--- a/lib/active_record/json_validator/validator.rb
+++ b/lib/active_record/json_validator/validator.rb
@@ -25,9 +25,9 @@ class JsonValidator < ActiveModel::EachValidator
     return if errors.empty? && record.send(:"#{attribute}_invalid_json").blank?
 
     # Add error message to the attribute
-    details = errors.map { |e| JSONSchemer::Errors.pretty(e) }
+    details = errors.map { |e| e.fetch('error') }
     message(errors).each do |error|
-      error = JSONSchemer::Errors.pretty(error) if error.is_a?(Hash)
+      error = error.fetch('error') if error.is_a?(Hash)
       record.errors.add(attribute, error, errors: details, value: value)
     end
   end

--- a/spec/json_validator_spec.rb
+++ b/spec/json_validator_spec.rb
@@ -64,12 +64,12 @@ describe JsonValidator do
 
       specify do
         expect(user).not_to be_valid
-        expect(user.errors.full_messages).to eql(['Data root is missing required keys: country', 'Other data missing_keys country'])
+        expect(user.errors.full_messages).to eql(['Data object at root is missing required properties: country', 'Other data missing_keys country'])
         expect(user.errors.group_by_attribute[:data].first).to have_attributes(
-          options: include(errors: ['root is missing required keys: country'])
+          options: include(errors: ['object at root is missing required properties: country'])
         )
         expect(user.errors.group_by_attribute[:other_data].first).to have_attributes(
-          options: include(errors: ['root is missing required keys: country'])
+          options: include(errors: ['object at root is missing required properties: country'])
         )
         expect(user.data).to eql({ 'city' => 'Quebec City' })
         expect(user.data_invalid_json).to be_nil

--- a/spec/json_validator_spec.rb
+++ b/spec/json_validator_spec.rb
@@ -41,8 +41,8 @@ describe JsonValidator do
 
         default_country_attribute :smart_data, country: 'Canada'
 
-        serialize :data, JSON
-        serialize :other_data, JSON
+        serialize :data, coder: JSON
+        serialize :other_data, coder: JSON
         validates :data, json: { schema: schema, message: ->(errors) { errors } }
         validates :other_data, json: { schema: schema, message: ->(errors) { errors.map { |error| error['details'].to_a.flatten.join(' ') } } }
         validates :smart_data, json: { value: ->(record, _, _) { record[:smart_data] }, schema: schema, message: ->(errors) { errors } }

--- a/spec/support/macros/database_macros.rb
+++ b/spec/support/macros/database_macros.rb
@@ -25,6 +25,6 @@ module DatabaseMacros
     adapter.reset_database!
 
     # Silence everything
-    ActiveRecord::Base.logger = ActiveRecord::Migration.verbose = false
+    ActiveRecord::Base.logger = ActiveRecord::Migration.verbose = nil
   end
 end


### PR DESCRIPTION
This upgrades to json_schemer 2.0, which is the latest major version. It
includes support for all current JSON Schema versions and new keywords
(eg, `unevaluatedProperties`). There are also new features that users of
this library may find helpful:

- Symbol key support for schemas and data
- Custom error messages with i18n or `x-error` keyword (it would be
  great to get feedback on this from your users)
- Global configuration options

Using 2.0 will likely require a major version bump because it comes with
breaking changes. See the [changelog][0] for more details.

Closes:
- https://github.com/mirego/activerecord_json_validator/issues/72
- https://github.com/mirego/activerecord_json_validator/issues/73

[0]: https://github.com/davishmcclurg/json_schemer/blob/main/CHANGELOG.md